### PR TITLE
Always get the block number for a contract

### DIFF
--- a/ethereumetl/jobs/export_all_common.py
+++ b/ethereumetl/jobs/export_all_common.py
@@ -326,12 +326,9 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
             job.run()
             contracts = inmemory_exporter.get_items('contract')
             # HACKHACK: add block_number to contracts when processing a single block
-            if len(blocks) == 1:
-                for contract in contracts:
-                    contract['block_number'] = blocks[0]['number']
-                    contract['block_hash'] = blocks[0]['hash']
-                    contract['block_timestamp'] = blocks[0]['timestamp']
-                    contracts = enrich_contracts(blocks, contracts)
+            for contract in contracts:
+                contract['block_number'] = blocks[0]['number']
+                contracts = enrich_contracts(blocks, contracts)
             contracts_exporters = get_multi_item_exporter(
                 [contracts_file_exporter, postgres_exporter])
             contracts_exporters.open()

--- a/ethereumetl/jobs/export_all_common.py
+++ b/ethereumetl/jobs/export_all_common.py
@@ -329,6 +329,8 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
             if len(blocks) == 1:
                 for contract in contracts:
                     contract['block_number'] = blocks[0]['number']
+                    contract['block_hash'] = blocks[0]['hash']
+                    contract['block_timestamp'] = blocks[0]['timestamp']
                     contracts = enrich_contracts(blocks, contracts)
             contracts_exporters = get_multi_item_exporter(
                 [contracts_file_exporter, postgres_exporter])

--- a/ethereumetl/jobs/export_all_common.py
+++ b/ethereumetl/jobs/export_all_common.py
@@ -325,9 +325,10 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
                 max_workers=max_workers)
             job.run()
             contracts = inmemory_exporter.get_items('contract')
-            # HACKHACK: add block_number to contracts when processing a single block
             for contract in contracts:
-                contract['block_number'] = blocks[0]['number']
+                contract_block_number = next((transaction["block_number"]
+                                              for transaction in transactions if transaction["receipt_contract_address"] == contract["address"]))
+                contract['block_number'] = contract_block_number
                 contracts = enrich_contracts(blocks, contracts)
             contracts_exporters = get_multi_item_exporter(
                 [contracts_file_exporter, postgres_exporter])


### PR DESCRIPTION
Use the in-memory transactions to find the block number where a contract was created.

Uses Python dictionary comprehension and the `next()` function to retrieve the block number.