### PR TITLE
Updated ETL for `contract_creations`, `tokens` and `token_updates`

### DIFF
--- a/blockchainetl/jobs/exporters/postgres_item_exporter.py
+++ b/blockchainetl/jobs/exporters/postgres_item_exporter.py
@@ -51,7 +51,11 @@ class PostgresItemExporter:
             if item_group:
                 connection = self.engine.connect()
                 converted_items = list(self.convert_items(item_group))
-                connection.execute(insert_stmt, converted_items)
+                if type(insert_stmt) == list:
+                    for insert in insert_stmt:
+                        connection.execute(insert, converted_items)
+                else:
+                    connection.execute(insert_stmt, converted_items)
 
     def convert_items(self, items):
         for item in items:

--- a/blockchainetl/streaming/postgres_utils.py
+++ b/blockchainetl/streaming/postgres_utils.py
@@ -9,7 +9,8 @@ def create_insert_statement_for_table(table):
         insert_stmt = insert_stmt.on_conflict_do_update(
             index_elements=primary_key_fields,
             set_={
-                column.name: insert_stmt.excluded[column.name] for column in table.columns if not column.primary_key
+                column.name: insert_stmt.excluded[column.name] for column in table.columns 
+                                if not column.primary_key and not ("immutable" in column.info and column.info["immutable"])
             }
         )
 

--- a/ethereumetl/cli/__init__.py
+++ b/ethereumetl/cli/__init__.py
@@ -46,7 +46,7 @@ logging_basic_config()
 
 
 @click.group()
-@click.version_option(version='1.10.1-spicehq/release/v1.0.5')
+@click.version_option(version='1.10.1-spicehq/release/v1.0.11')
 @click.pass_context
 def cli(ctx):
     pass

--- a/ethereumetl/jobs/export_all_common.py
+++ b/ethereumetl/jobs/export_all_common.py
@@ -48,7 +48,7 @@ from ethereumetl.jobs.exporters.token_transfers_item_exporter import token_trans
 from ethereumetl.jobs.exporters.tokens_item_exporter import tokens_item_exporter
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.streaming.enrich import enrich_contracts, enrich_logs, enrich_tokens
-from ethereumetl.streaming.postgres_tables import BLOCKS, TRANSACTIONS, LOGS, TOKEN_TRANSFERS, CONTRACTS, TOKENS, TOKEN_UPDATES
+from ethereumetl.streaming.postgres_tables import BLOCKS, TRANSACTIONS, LOGS, TOKEN_TRANSFERS, CONTRACT_CREATIONS, TOKENS, TOKEN_UPDATES
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.web3_utils import build_web3
 
@@ -147,7 +147,7 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
                     'transaction': create_insert_statement_for_table(TRANSACTIONS),
                     'log': create_insert_statement_for_table(LOGS),
                     'token_transfer': create_insert_statement_for_table(TOKEN_TRANSFERS),
-                    'contract': create_insert_statement_for_table(CONTRACTS),
+                    'contract': create_insert_statement_for_table(CONTRACT_CREATIONS),
                     'token': [create_insert_statement_for_table(TOKENS), create_insert_statement_for_table(TOKEN_UPDATES)],
                 },
             )
@@ -383,9 +383,6 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
                 tokens = inmemory_exporter.get_items('token')
                 tokens = enrich_tokens(blocks, tokens)
                 for token in tokens:
-                    token["creation_block_number"] = token["block_number"]
-                    token["creation_block_timestamp"] = token["block_timestamp"]
-                    token["creation_block_hash"] = token["block_hash"]
                     token["updated_block_number"] = token["block_number"]
                     token["updated_block_timestamp"] = token["block_timestamp"]
                     token["updated_block_hash"] = token["block_hash"]

--- a/ethereumetl/jobs/export_all_common.py
+++ b/ethereumetl/jobs/export_all_common.py
@@ -48,7 +48,7 @@ from ethereumetl.jobs.exporters.token_transfers_item_exporter import token_trans
 from ethereumetl.jobs.exporters.tokens_item_exporter import tokens_item_exporter
 from ethereumetl.providers.auto import get_provider_from_uri
 from ethereumetl.streaming.enrich import enrich_contracts, enrich_logs, enrich_tokens
-from ethereumetl.streaming.postgres_tables import BLOCKS, TRANSACTIONS, LOGS, TOKEN_TRANSFERS, CONTRACTS, TOKENS
+from ethereumetl.streaming.postgres_tables import BLOCKS, TRANSACTIONS, LOGS, TOKEN_TRANSFERS, CONTRACTS, TOKENS, TOKEN_UPDATES
 from ethereumetl.thread_local_proxy import ThreadLocalProxy
 from ethereumetl.web3_utils import build_web3
 
@@ -60,7 +60,7 @@ def is_log_filter_supported(provider_uri):
     return 'infura' not in provider_uri
 
 
-def extract_csv_column_unique(input_path, output, column):
+def extract_csv_column_unique(input_path, output, column, other_columns = None):
     set_max_field_size_limit()
     with smart_open(input_path, 'r') as input_file, smart_open(output, 'w') as output_file:
         reader = csv.DictReader(input_file)
@@ -69,7 +69,12 @@ def extract_csv_column_unique(input_path, output, column):
             if row[column] in seen:
                 continue
             seen.add(row[column])
-            output_file.write(row[column] + '\n')
+
+            output = row[column]
+            if other_columns:
+                for other_column in other_columns:
+                    output = output + "," + row[other_column]
+            output_file.write(output + '\n')
 
 
 def get_multi_item_exporter(item_exporters: list):
@@ -143,9 +148,8 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
                     'log': create_insert_statement_for_table(LOGS),
                     'token_transfer': create_insert_statement_for_table(TOKEN_TRANSFERS),
                     'contract': create_insert_statement_for_table(CONTRACTS),
-                    'token': create_insert_statement_for_table(TOKENS),
+                    'token': [create_insert_statement_for_table(TOKENS), create_insert_statement_for_table(TOKEN_UPDATES)],
                 },
-                converters=[ListJoinItemConverter('function_sighashes', ',')]
             )
 
         inmemory_exporter = InMemoryItemExporter(item_types=[
@@ -347,7 +351,7 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
                 token_transfers_file=token_transfers_file,
             ))
             extract_csv_column_unique(
-                token_transfers_file, token_addresses_file, 'token_address')
+                token_transfers_file, token_addresses_file, 'token_address', ['block_number'])
 
             tokens_output_dir = '{output_dir}/tokens{partition_dir}'.format(
                 output_dir=output_dir,
@@ -367,20 +371,24 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
             with smart_open(token_addresses_file, 'r') as token_addresses:
                 tokens_file_exporter = tokens_item_exporter(tokens_file)
 
+                token_addresses_iterable = csv.DictReader(token_addresses, fieldnames=["token_address", "block_number"])
+
                 job = ExportTokensJob(
-                    token_addresses_iterable=(
-                        token_address.strip() for token_address in token_addresses),
+                    token_addresses_iterable=token_addresses_iterable,
                     web3=ThreadLocalProxy(lambda: build_web3(
                         get_provider_from_uri(provider_uri))),
                     item_exporter=inmemory_exporter,
                     max_workers=max_workers)
                 job.run()
                 tokens = inmemory_exporter.get_items('token')
-                # HACKHACK: add block_number to tokens when processing a single block
-                if len(blocks) == 1:
-                    for token in tokens:
-                        token['block_number'] = blocks[0]['number']
-                    tokens = enrich_tokens(blocks, tokens)
+                tokens = enrich_tokens(blocks, tokens)
+                for token in tokens:
+                    token["creation_block_number"] = token["block_number"]
+                    token["creation_block_timestamp"] = token["block_timestamp"]
+                    token["creation_block_hash"] = token["block_hash"]
+                    token["updated_block_number"] = token["block_number"]
+                    token["updated_block_timestamp"] = token["block_timestamp"]
+                    token["updated_block_hash"] = token["block_hash"]
                 tokens_exporters = get_multi_item_exporter(
                     [tokens_file_exporter, postgres_exporter])
                 tokens_exporters.open()

--- a/ethereumetl/jobs/export_tokens_job.py
+++ b/ethereumetl/jobs/export_tokens_job.py
@@ -44,7 +44,10 @@ class ExportTokensJob(BaseJob):
 
     def _export_tokens(self, token_addresses):
         for token_address in token_addresses:
-            self._export_token(token_address)
+            if type(token_address) is dict:
+                self._export_token(token_address["token_address"], int(token_address["block_number"]))
+            else:
+                self._export_token(token_address)
 
     def _export_token(self, token_address, block_number=None):
         token = self.token_service.get_token(token_address)

--- a/ethereumetl/jobs/exporters/contracts_item_exporter.py
+++ b/ethereumetl/jobs/exporters/contracts_item_exporter.py
@@ -25,6 +25,7 @@ from blockchainetl.jobs.exporters.composite_item_exporter import CompositeItemEx
 
 FIELDS_TO_EXPORT = [
     'address',
+    'bytecode',
     'function_sighashes',
     'is_erc20',
     'is_erc721',

--- a/ethereumetl/streaming/postgres_tables.py
+++ b/ethereumetl/streaming/postgres_tables.py
@@ -124,8 +124,8 @@ TRACES = Table(
     Column('trace_id', String, primary_key=True),
 )
 
-CONTRACTS = Table(
-    'contracts', metadata,
+CONTRACT_CREATIONS = Table(
+    'contract_creations', metadata,
     Column('address', String, primary_key=True),
     Column('bytecode', String),
     Column('function_sighashes', String),
@@ -157,9 +157,9 @@ TOKENS = Table(
     Column('symbol', String),
     Column('decimals', Integer),
     Column('total_supply', String),
-    Column('creation_block_number', BigInteger, info={"immutable": True}),
-    Column('creation_block_timestamp', BigInteger, info={"immutable": True}),
-    Column('creation_block_hash', String, info={"immutable": True}),
+    Column('block_number', BigInteger, info={"immutable": True}),
+    Column('block_timestamp', BigInteger, info={"immutable": True}),
+    Column('block_hash', String, info={"immutable": True}),
     Column('updated_block_number', BigInteger),
     Column('updated_block_timestamp', BigInteger),
     Column('updated_block_hash', String),
@@ -170,6 +170,7 @@ TOKEN_UPDATES = Table(
     Column('address', String, primary_key=True),
     Column('name', String),
     Column('symbol', String),
+    Column('decimals', Integer),
     Column('total_supply', String),
     Column('block_number', BigInteger),
     Column('block_timestamp', BigInteger),

--- a/ethereumetl/streaming/postgres_tables.py
+++ b/ethereumetl/streaming/postgres_tables.py
@@ -127,12 +127,13 @@ TRACES = Table(
 CONTRACTS = Table(
     'contracts', metadata,
     Column('address', String, primary_key=True),
+    Column('bytecode', String),
     Column('function_sighashes', String),
     Column('is_erc20', Boolean),
     Column('is_erc721', Boolean),
     Column('block_number', BigInteger),
     Column('block_timestamp', BigInteger),
-    Column('block_hash', String, primary_key=True),
+    Column('block_hash', String),
 )
 
 RECEIPTS = Table(
@@ -151,10 +152,26 @@ RECEIPTS = Table(
 
 TOKENS = Table(
     'tokens', metadata,
-    Column('address', String),
+    Column('address', String, primary_key=True),
     Column('name', String),
     Column('symbol', String),
     Column('decimals', Integer),
     Column('total_supply', String),
+    Column('creation_block_number', BigInteger, info={"immutable": True}),
+    Column('creation_block_timestamp', BigInteger, info={"immutable": True}),
+    Column('creation_block_hash', String, info={"immutable": True}),
+    Column('updated_block_number', BigInteger),
+    Column('updated_block_timestamp', BigInteger),
+    Column('updated_block_hash', String),
+)
+
+TOKEN_UPDATES = Table(
+    'token_updates', metadata,
+    Column('address', String, primary_key=True),
+    Column('name', String),
+    Column('symbol', String),
+    Column('total_supply', String),
     Column('block_number', BigInteger),
+    Column('block_timestamp', BigInteger),
+    Column('block_hash', String, primary_key=True),
 )


### PR DESCRIPTION
Closes https://github.com/spicehq/data-platform/issues/876

- Always get the block number for a token
- Handle inserting into multiple tables (for `tokens` and `token_updates`)
- Add the concept of an `immutable` column for `block_timestamp`, `block_number` and `block_hash` on `tokens`
- Use v1.0.11