### PR TITLE
Handle HTTPError from Alchemy

### DIFF
--- a/ethereumetl/cli/__init__.py
+++ b/ethereumetl/cli/__init__.py
@@ -46,7 +46,7 @@ logging_basic_config()
 
 
 @click.group()
-@click.version_option(version='1.11.0-spicehq/release/v1.0.17')
+@click.version_option(version='1.11.0-spicehq/release/v1.0.18')
 @click.pass_context
 def cli(ctx):
     pass

--- a/ethereumetl/jobs/export_all_common.py
+++ b/ethereumetl/jobs/export_all_common.py
@@ -27,6 +27,8 @@ import os
 import shutil
 from time import time
 
+from requests import HTTPError
+
 from blockchainetl.jobs.exporters.in_memory_item_exporter import InMemoryItemExporter
 from blockchainetl.jobs.exporters.postgres_item_exporter import PostgresItemExporter
 from blockchainetl.file_utils import smart_open
@@ -306,6 +308,8 @@ def export_all_common(partitions, output_dir, postgres_connection_string, provid
         try:
             job.run()
         except HistoricalStateUnavailableError:
+            geth_traces_available = False
+        except HTTPError:
             geth_traces_available = False
 
         contracts_output_dir = '{output_dir}/contracts{partition_dir}'.format(


### PR DESCRIPTION
The `debug` API is not available from Alchemy to get the geth traces. If this is the case, fallback to the other contract exporting logic.