### PR TITLE
Add option to skip using geth traces for contract creations

### DIFF
--- a/ethereumetl/cli/__init__.py
+++ b/ethereumetl/cli/__init__.py
@@ -46,7 +46,7 @@ logging_basic_config()
 
 
 @click.group()
-@click.version_option(version='1.11.0-spicehq/release/v1.0.18')
+@click.version_option(version='1.11.0-spicehq/release/v1.0.19')
 @click.pass_context
 def cli(ctx):
     pass

--- a/ethereumetl/cli/export_all.py
+++ b/ethereumetl/cli/export_all.py
@@ -119,10 +119,11 @@ def get_partitions(start, end, partition_batch_size, provider_uri):
 @click.option('-P', '--postgres-connection-string', default='', show_default=False, type=str, help='Postgres connection string.')
 @click.option('-w', '--max-workers', default=5, show_default=True, type=int, help='The maximum number of workers.')
 @click.option('-B', '--export-batch-size', default=100, show_default=True, type=int, help='The number of requests in JSON RPC batches.')
+@click.option('--skip-geth-traces', default=False, show_default=True, type=bool, help='Whether to skip using geth traces to get contracts')
 @click.option('-c', '--chain', default='ethereum', show_default=True, type=str, help='The chain network to connect to.')
 def export_all(start, end, partition_batch_size, provider_uri, output_dir, postgres_connection_string, max_workers, export_batch_size,
-               chain='ethereum'):
+               chain='ethereum', skip_geth_traces=False):
     """Exports all data for a range of blocks."""
     provider_uri = check_classic_provider_uri(chain, provider_uri)
     export_all_common(get_partitions(start, end, partition_batch_size, provider_uri),
-                      output_dir, postgres_connection_string, provider_uri, max_workers, export_batch_size)
+                      output_dir, postgres_connection_string, provider_uri, max_workers, export_batch_size, skip_geth_traces)


### PR DESCRIPTION
- Add option to skip using the geth traces entirely, as that is causing dev to fail on ETL all of the time.
- Bump to version v1.0.19